### PR TITLE
add .PHONY target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ LDFLAGS=-T $(SRC_DIR)/linker_script.ld -nostartfile
 # Source Files
 SRC_FILES=$(wildcard $(SRC_DIR)/*.c)
 
+# PHONY Target
+.PHONY: all clean
+
 # Output
 TARGET=firmware
 


### PR DESCRIPTION
This pull request adds `.PHONY` declarations to the `all` and `clean` targets in the Makefile to ensure they are always executed as ***commands***, even if ***files*** with the **same** names exist. This prevents conflicts and improves the reliability of the Makefile